### PR TITLE
Align navbar links with each other

### DIFF
--- a/components/NavbarLink.tsx
+++ b/components/NavbarLink.tsx
@@ -14,7 +14,7 @@ const NavbarLink = ({ text, href }: NavbarLinkProps) => {
 
   return (
     <Link href={href}>
-      <a className={`${activeStyle} text-black dark:text-white`}>{text}</a>
+      <a className={`${activeStyle} border-b-[1px] pb-1 border-transparent text-black dark:text-white`}>{text}</a>
     </Link>
   )
 }

--- a/styles/NavbarLink.module.css
+++ b/styles/NavbarLink.module.css
@@ -1,6 +1,4 @@
 .halfBorderBottom {
-  padding-bottom: 4px;
-  border-bottom: 1px solid;
   border-image: linear-gradient(to right, #3F3D56 50%, transparent 50%) 100% 1;
 }
 


### PR DESCRIPTION
Align navbar links with each other so that they don't change position based on their active state.

Before:

![Peek 2022-06-15 16-48](https://user-images.githubusercontent.com/20467669/173857086-18595bd6-6a3f-4dd5-abf5-1737ba6405a3.gif)

After:

![Peek 2022-06-15 16-482](https://user-images.githubusercontent.com/20467669/173857151-5dc6dcac-8489-4b9e-8c19-f04977cd28fe.gif)

Which one is better? :thinking: 