### PR TITLE
Protect /create and /manage routes

### DIFF
--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -1,8 +1,20 @@
+import { useWallet } from '@solana/wallet-adapter-react'
 import type { NextPage } from 'next'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 
 import CreateWalletForm from '../components/CreateWalletForm'
 
 const Create: NextPage = () => {
+  const { connected } = useWallet()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (router.isReady && !connected) {
+      router.replace('/')
+    }
+  }, [router, connected])
+
   return (
     <div className="container mx-auto gap-10 flex flex-col justify-center items-center my-10">
       <h1 className="w-full text-center md:text-left text-3xl md:text-4xl font-bold text-primary dark:text-white">

--- a/pages/manage/[pubkey].tsx
+++ b/pages/manage/[pubkey].tsx
@@ -1,4 +1,7 @@
+import { useWallet } from '@solana/wallet-adapter-react'
 import type { NextPage } from 'next'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 import WalletDetails from '../../components/WalletDetails'
 
 export const getServerSideProps = async (context: any) => {
@@ -25,6 +28,15 @@ interface Props {
 }
 
 const WalletDetailsPage: NextPage<Props> = ({ wallet }) => {
+  const { connected } = useWallet()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (router.isReady && !connected) {
+      router.replace('/')
+    }
+  }, [router, connected])
+
   return (
     <div className="container mx-auto px-6 sm:px-0 gap-10 flex flex-col justify-center items-center my-10">
       <WalletDetails wallet={wallet} />

--- a/pages/manage/index.tsx
+++ b/pages/manage/index.tsx
@@ -14,7 +14,6 @@ const Manage: NextPage = () => {
     }
   }, [router, connected])
 
-
   return (
     <div className="container mx-auto pt-8 px-6 flex flex-col justify-start items-start">
       <h1 className="text-2xl font-extrabold font-['Nunito',sans-serif]">Your Hydra Wallets</h1>

--- a/pages/manage/index.tsx
+++ b/pages/manage/index.tsx
@@ -1,8 +1,20 @@
 import { useWallet } from '@solana/wallet-adapter-react'
 import type { NextPage } from 'next'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 import WalletsList from '../../components/WalletsList'
 
 const Manage: NextPage = () => {
+  const { connected } = useWallet()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (router.isReady && !connected) {
+      router.replace('/')
+    }
+  }, [router, connected])
+
+
   return (
     <div className="container mx-auto pt-8 px-6 flex flex-col justify-start items-start">
       <h1 className="text-2xl font-extrabold font-['Nunito',sans-serif]">Your Hydra Wallets</h1>


### PR DESCRIPTION
This simply redirects the user back to the home page `/` whenever they visit `/create` or `/manage` without having their wallet connected.

Only client-side protection is possible since we have no way on the server to tell whether the user's wallet is connected or not as it is done on the client side (through the browser extension).

Resolves #51 