### PR TITLE
Add postinstall hook for prisma

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@glasseaters/hydra-sdk": "^0.3.2",
@@ -30,6 +31,7 @@
     "eslint": "8.18.0",
     "eslint-config-next": "12.1.6",
     "postcss": "^8.4.14",
+    "prisma": "^3.15.2",
     "tailwindcss": "^3.0.24",
     "typescript": "4.7.2"
   }


### PR DESCRIPTION
Add a postinstall hook that runs `prisma generate` to generate the Prisma
client whenever packages are installed.

Fixes problems on Vercel.