### PR TITLE
Update wallet creation error handling

### DIFF
--- a/components/CreateWalletForm.tsx
+++ b/components/CreateWalletForm.tsx
@@ -38,6 +38,7 @@ const CreateWalletForm = () => {
 
   const [formState, setFormState] = useState('idle' as FormState)
   const [errorMsg, setErrorMsg] = useState('')
+  const [logs, setLogs] = useState([])
 
   const onSubmit = async (values: any) => {
     if (!wallet) {
@@ -47,6 +48,7 @@ const CreateWalletForm = () => {
     }
 
     try {
+      setLogs([])
       const fanoutSdk = new FanoutClient(connection, wallet)
 
       // Calculate fanout public key
@@ -104,6 +106,7 @@ const CreateWalletForm = () => {
         const json = await res.json()
         setFormState('error')
         setErrorMsg(json.msg)
+        setLogs(json.logs)
       }
     } catch (error: any) {
       setFormState('error')
@@ -151,6 +154,7 @@ const CreateWalletForm = () => {
         submittingMsg="Creating Hydra Wallet..."
         successMsg="Successfully created Hydra Wallet!"
         errorMsg={errorMsg}
+        logs={logs}
       />
       <div className="w-full md:w-1/2 flex flex-col items-center md:items-start gap-10">
         <div className="form-control w-4/5">

--- a/components/CreateWalletForm.tsx
+++ b/components/CreateWalletForm.tsx
@@ -78,7 +78,7 @@ const CreateWalletForm = () => {
       const txSigned = await wallet.signTransaction(tx)
 
       // Send API request
-      const res = await fetch('api/createHydraWallet', {
+      const res = await fetch('/api/createHydraWallet', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/components/FormStateAlert.tsx
+++ b/components/FormStateAlert.tsx
@@ -5,6 +5,7 @@ type FormStateAlertProps = {
   submittingMsg: string
   successMsg: string
   errorMsg: string
+  logs?: string[]
 }
 
 const FormStateAlert = ({
@@ -12,6 +13,7 @@ const FormStateAlert = ({
   submittingMsg,
   successMsg,
   errorMsg,
+  logs,
 }: FormStateAlertProps) => {
   const alertClass: Record<FormState, string> = {
     idle: '',
@@ -39,8 +41,19 @@ const FormStateAlert = ({
     return <div></div>
   }
 
+  const LogsCollapse = () =>
+    logs?.length ? (
+      <div tabIndex={0} className="collapse collapse-arrow">
+        <input type="checkbox" />
+        <div className="collapse-title font-bold">Logs</div>
+        <ul className="collapse-content">
+          {logs.map((log, idx) => <li key={idx}>{log}</li>)}
+        </ul>
+      </div>
+    ) : null
+
   return (
-    <div className={`alert ${alertClass[state]} shadow-lg`}>
+    <div className={`alert ${alertClass[state]} shadow-lg flex-col items-start gap-0`}>
       <div>
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -57,6 +70,7 @@ const FormStateAlert = ({
         </svg>
         <span>{alertMsg[state]}</span>
       </div>
+      <LogsCollapse />
     </div>
   )
 }


### PR DESCRIPTION
- Send back and display transaction logs on transaction error
- Handle database unique constraint violation when creating a wallet with an existing `(pubkey, cluster)` pair

Regarding the second point, we actually cannot set a `@unique` constraint on the `name` field of the `Wallet` model because it is fine to have two wallets with the same name but on different clusters. Instead, two wallets with the same name have essentially the same public key (as it is derived from the name), this is already accounted for by the primary key `@@id([cluster, pubkey])`.

CC @Tess99854 and @rishabh-vasudevan 