### PR TITLE
Send SPL token only if checked

### DIFF
--- a/components/CreateWalletForm.tsx
+++ b/components/CreateWalletForm.tsx
@@ -90,7 +90,7 @@ const CreateWalletForm = () => {
           authority: wallet.publicKey.toBase58(),
           memberShipType: values.model,
           acceptSPL: values.acceptSPL,
-          splToken: values.pubKeySPL,
+          splToken: values.acceptSPL ? values.pubKeySPL : undefined,
           // TODO: Include mint public key for token membership model
           totalShares: values.shares,
           cluster,


### PR DESCRIPTION
Send the SPL token with the wallet creation request only if "Accept SPL Tokens" is checked.