### PR TITLE
Fund wallet button and modal box

### DIFF
--- a/components/CopyToClipboard.tsx
+++ b/components/CopyToClipboard.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react"
+import { FaCheck, FaCopy } from "react-icons/fa"
+
+type CopyToClipboardProps = {
+  text: string
+}
+
+const CopyToClipboard = ({ text }: CopyToClipboardProps) => {
+  const [copied, setCopied] = useState(false)
+
+  const copyText = () => {
+    navigator.clipboard.writeText(text)
+      .then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1500)
+      })
+      .catch(error => console.error(error))
+  }
+
+  return (
+    <span className="btn btn-secondary" onClick={copyText}>
+      { copied ? <FaCheck /> : <FaCopy /> }
+    </span>
+  )
+}
+
+export default CopyToClipboard

--- a/components/FundWalletModal.tsx
+++ b/components/FundWalletModal.tsx
@@ -1,6 +1,6 @@
 import { Fanout } from '@glasseaters/hydra-sdk'
 import { useAnchorWallet, useConnection } from '@solana/wallet-adapter-react'
-import { PublicKey, SystemProgram, Transaction } from '@solana/web3.js'
+import { LAMPORTS_PER_SOL, PublicKey, SystemProgram, Transaction } from '@solana/web3.js'
 import { FormikErrors, useFormik } from 'formik'
 import { useEffect, useState } from 'react'
 import CopyToClipboard from './CopyToClipboard'
@@ -52,7 +52,7 @@ const FundWalletModal = ({ modalId, hydraWallet }: FundWalletModalProps) => {
       const ixTransfer = SystemProgram.transfer({
         fromPubkey: wallet.publicKey,
         toPubkey: new PublicKey(nativeAccount),
-        lamports: values.amount,
+        lamports: values.amount * LAMPORTS_PER_SOL,
       })
       tx.add(ixTransfer)
 
@@ -96,12 +96,6 @@ const FundWalletModal = ({ modalId, hydraWallet }: FundWalletModalProps) => {
     return errors
   }
 
-  const checkNumeric = (event: any) => {
-    if (event.key == '.') {
-      event.preventDefault()
-    }
-  }
-
   const formik = useFormik({
     initialValues,
     onSubmit,
@@ -140,12 +134,11 @@ const FundWalletModal = ({ modalId, hydraWallet }: FundWalletModalProps) => {
             </div>
             <div className="form-control w-full">
               <label className="label">
-                <span className="label-text">Amount (Lamports)</span>
+                <span className="label-text">Amount (SOL)</span>
               </label>
               <input
                 type="number"
                 className="input input-bordered w-full"
-                onKeyPress={checkNumeric}
                 {...formik.getFieldProps('amount')}
               />
               <label className="label">

--- a/components/FundWalletModal.tsx
+++ b/components/FundWalletModal.tsx
@@ -3,6 +3,7 @@ import { useAnchorWallet, useConnection } from '@solana/wallet-adapter-react'
 import { PublicKey, SystemProgram, Transaction } from '@solana/web3.js'
 import { FormikErrors, useFormik } from 'formik'
 import { useEffect, useState } from 'react'
+import CopyToClipboard from './CopyToClipboard'
 import FormStateAlert, { FormState } from './FormStateAlert'
 
 type FundWalletModalProps = {
@@ -127,12 +128,15 @@ const FundWalletModal = ({ modalId, hydraWallet }: FundWalletModalProps) => {
               <label className="label">
                 <span className="label-text">Hydra Wallet Native Account</span>
               </label>
-              <input
-                type="text"
-                className="input input-bordered w-full"
-                value={nativeAccount}
-                readOnly
-              />
+              <div className="flex flex-row items-center gap-2">
+                <input
+                  type="text"
+                  className="input input-bordered w-full flex-1"
+                  value={nativeAccount}
+                  readOnly
+                />
+                <CopyToClipboard text={nativeAccount} />
+              </div>
             </div>
             <div className="form-control w-full">
               <label className="label">

--- a/components/FundWalletModal.tsx
+++ b/components/FundWalletModal.tsx
@@ -1,0 +1,177 @@
+import { Fanout } from '@glasseaters/hydra-sdk'
+import { useAnchorWallet, useConnection } from '@solana/wallet-adapter-react'
+import { PublicKey, SystemProgram, Transaction } from '@solana/web3.js'
+import { FormikErrors, useFormik } from 'formik'
+import { useEffect, useState } from 'react'
+import FormStateAlert, { FormState } from './FormStateAlert'
+
+type FundWalletModalProps = {
+  modalId: string
+  hydraWallet: any
+}
+
+interface FormValues {
+  amount: number
+}
+
+const FundWalletModal = ({ modalId, hydraWallet }: FundWalletModalProps) => {
+  const [formState, setFormState] = useState('idle' as FormState)
+  const [errorMsg, setErrorMsg] = useState('')
+  const [nativeAccount, setNativeAccount] = useState('')
+  const { connection } = useConnection()
+  const wallet = useAnchorWallet()
+
+  const initialValues = {
+    amount: 0,
+  }
+
+  // Fetching the native account public key from the blockchain for now until
+  // it is available in the API and database
+  useEffect(() => {
+    (async () => {
+      const fanout = await Fanout.fromAccountAddress(
+        connection,
+        new PublicKey(hydraWallet.pubkey)
+      )
+      setNativeAccount(fanout.accountKey.toBase58())
+    })()
+  }, [connection, hydraWallet.pubkey])
+
+  const onSubmit = async (values: FormValues, { resetForm }) => {
+    if (!wallet) {
+      setFormState('error')
+      setErrorMsg('Please connect your wallet!')
+      return
+    }
+
+    try {
+      // Prepare transaction
+      const tx = new Transaction()
+      const ixTransfer = SystemProgram.transfer({
+        fromPubkey: wallet.publicKey,
+        toPubkey: new PublicKey(nativeAccount),
+        lamports: values.amount,
+      })
+      tx.add(ixTransfer)
+
+      // Sign transaction using user's wallet
+      tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash
+      tx.feePayer = wallet.publicKey
+      const txSigned = await wallet.signTransaction(tx)
+
+      // Send transaction
+      const signature = await connection.sendRawTransaction(
+        txSigned.serialize()
+      )
+      const result = await connection.confirmTransaction({
+        signature,
+        ...(await connection.getLatestBlockhash()),
+      })
+
+      if (result.value.err) {
+        setFormState('error')
+        setErrorMsg(
+          `Failed to confirm transaction: ${result.value.err.toString()}`
+        )
+      } else {
+        setFormState('success')
+        resetForm()
+      }
+    } catch (error: any) {
+      setFormState('error')
+      setErrorMsg(`Failed to fund wallet: ${error.message}`)
+    }
+  }
+
+  const validate = (values: FormValues) => {
+    const errors: FormikErrors<FormValues> = {}
+
+    if (!values.amount || values.amount < 0) {
+      errors.amount = 'Please enter a valid amount to transfer'
+    }
+
+    return errors
+  }
+
+  const checkNumeric = (event: any) => {
+    if (event.key == '.') {
+      event.preventDefault()
+    }
+  }
+
+  const formik = useFormik({
+    initialValues,
+    onSubmit,
+    validate,
+  })
+
+  return (
+    <div>
+      <input
+        type="checkbox"
+        id={modalId}
+        className="modal-toggle"
+        onChange={(event) => {
+          if (!event.target.checked) {
+            setFormState('idle')
+          }
+        }}
+      />
+      <label htmlFor={modalId} className="modal cursor-pointer">
+        <label className="modal-box relative" htmlFor="">
+          <h3 className="text-lg font-bold">Fund Hydra Wallet</h3>
+          <form className="py-4" onSubmit={formik.handleSubmit}>
+            <div className="form-control w-full">
+              <label className="label">
+                <span className="label-text">Hydra Wallet Native Account</span>
+              </label>
+              <input
+                type="text"
+                className="input input-bordered w-full"
+                value={nativeAccount}
+              />
+            </div>
+            <div className="form-control w-full">
+              <label className="label">
+                <span className="label-text">Amount (Lamports)</span>
+              </label>
+              <input
+                type="number"
+                className="input input-bordered w-full"
+                onKeyPress={checkNumeric}
+                {...formik.getFieldProps('amount')}
+              />
+              <label className="label">
+                <span className="label-text-alt text-red-500">
+                  {formik.errors.amount}
+                </span>
+              </label>
+            </div>
+            <FormStateAlert
+              state={formik.isSubmitting ? 'submitting' : formState}
+              submittingMsg={'Sending funds to Hydra Wallet...'}
+              successMsg={'Successfully transferred funds to Hydra Wallet!'}
+              errorMsg={errorMsg}
+            />
+            <div className="modal-action">
+              <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={
+                  !(formik.dirty && formik.isValid) || formik.isSubmitting
+                }
+              >
+                Send
+              </button>
+              <label htmlFor={modalId} className="btn">
+                Cancel
+              </label>
+            </div>
+          </form>
+        </label>
+      </label>
+    </div>
+  )
+}
+
+export default FundWalletModal

--- a/components/FundWalletModal.tsx
+++ b/components/FundWalletModal.tsx
@@ -131,6 +131,7 @@ const FundWalletModal = ({ modalId, hydraWallet }: FundWalletModalProps) => {
                 type="text"
                 className="input input-bordered w-full"
                 value={nativeAccount}
+                readOnly
               />
             </div>
             <div className="form-control w-full">

--- a/components/FundWalletModal.tsx
+++ b/components/FundWalletModal.tsx
@@ -17,6 +17,7 @@ interface FormValues {
 const FundWalletModal = ({ modalId, hydraWallet }: FundWalletModalProps) => {
   const [formState, setFormState] = useState('idle' as FormState)
   const [errorMsg, setErrorMsg] = useState('')
+  const [errorLogs, setErrorLogs] = useState([])
   const [nativeAccount, setNativeAccount] = useState('')
   const { connection } = useConnection()
   const wallet = useAnchorWallet()
@@ -78,6 +79,7 @@ const FundWalletModal = ({ modalId, hydraWallet }: FundWalletModalProps) => {
         resetForm()
       }
     } catch (error: any) {
+      setErrorLogs(error.logs)
       setFormState('error')
       setErrorMsg(`Failed to fund wallet: ${error.message}`)
     }
@@ -152,6 +154,7 @@ const FundWalletModal = ({ modalId, hydraWallet }: FundWalletModalProps) => {
               submittingMsg={'Sending funds to Hydra Wallet...'}
               successMsg={'Successfully transferred funds to Hydra Wallet!'}
               errorMsg={errorMsg}
+              logs={errorLogs}
             />
             <div className="modal-action">
               <button

--- a/components/WalletDetails.tsx
+++ b/components/WalletDetails.tsx
@@ -10,6 +10,7 @@ import AddMemberModal from './AddMemberModal'
 import MembersTable from './MembersTable'
 import styles from '../styles/MemembersList.module.css'
 import Link from 'next/link'
+import FundWalletModal from './FundWalletModal'
 
 type WalletDetailsProps = {
   wallet: any
@@ -27,7 +28,10 @@ const WalletDetails = ({ wallet, members }: WalletDetailsProps) => {
           <span className="break-words">{wallet.pubkey}</span>
         </div>
 
-        <div className=" w-full md:w-1/3 flex justify-center md:justify-end">
+        <div className=" w-full md:w-1/3 flex justify-center md:justify-end gap-2">
+          <label htmlFor="fund-wallet-modal" className="btn btn-secondary">
+            Fund Wallet
+          </label>
           <div className="tooltip tooltip-secondary" data-tip="Add members">
             <label
               htmlFor="add-member-modal"
@@ -115,7 +119,8 @@ const WalletDetails = ({ wallet, members }: WalletDetailsProps) => {
         </div>
       </div>
 
-      <AddMemberModal hydraWallet = {wallet} />
+      <AddMemberModal hydraWallet={wallet} />
+      <FundWalletModal modalId="fund-wallet-modal" hydraWallet={wallet} />
     </div>
   )
 }


### PR DESCRIPTION
- Currently fetches the native account public key from the blockchain until it is available in the API and the database
- TODO: add a copy icon next to the native account textbox?

Resolves #92 