### PR TITLE
Separate out distribution logic

### DIFF
--- a/components/WalletDetails.tsx
+++ b/components/WalletDetails.tsx
@@ -15,9 +15,13 @@ import Link from 'next/link'
 import { Fanout, FanoutClient } from '@glasseaters/hydra-sdk'
 import { useCallback, useEffect, useState } from 'react'
 import { useConnection, useAnchorWallet } from '@solana/wallet-adapter-react'
-import { LAMPORTS_PER_SOL, PublicKey, SystemProgram, Transaction } from '@solana/web3.js'
+import { LAMPORTS_PER_SOL, PublicKey, Transaction } from '@solana/web3.js'
 import { NATIVE_MINT } from '@solana/spl-token'
 import FormStateAlert, { FormState } from './FormStateAlert'
+import {
+  distributeAllTransaction,
+  distributeMemberTransaction,
+} from '../utils/distribute'
 
 type WalletDetailsProps = {
   initialWallet: any
@@ -43,9 +47,8 @@ const WalletDetails = ({ initialWallet, members }: WalletDetailsProps) => {
 
   //toggle refresh page on fund distribution
   const updateRefresh = (newRefresh: { msg: string }) => {
-  setRefresh(newRefresh)
+    setRefresh(newRefresh)
   }
-
 
   //refresh function
   const fetchData = useCallback(async () => {
@@ -66,7 +69,9 @@ const WalletDetails = ({ initialWallet, members }: WalletDetailsProps) => {
         nativeAccountPubkey
       )
       const Rentbalance = await connection.getMinimumBalanceForRentExemption(1)
-      setBalance(((nativeAccountInfo?.lamports ?? 0) - Rentbalance) / LAMPORTS_PER_SOL)
+      setBalance(
+        ((nativeAccountInfo?.lamports ?? 0) - Rentbalance) / LAMPORTS_PER_SOL
+      )
       setAvailableShares(fanoutObject.totalAvailableShares.toString())
       setTimeout(function () {
         setFormState2('idle')
@@ -78,7 +83,6 @@ const WalletDetails = ({ initialWallet, members }: WalletDetailsProps) => {
       setErrorMsg(`Failed to refresh: ${error.message}`)
     }
   }, [])
-
 
   //useEffect for refreshing page
   useEffect(() => {
@@ -125,40 +129,32 @@ const WalletDetails = ({ initialWallet, members }: WalletDetailsProps) => {
     })()
   }, [connection, wallet.pubkey])
 
-  const handleDistribute = async (memberPubkey) => {
-    setFormState('submitting')
+  const handleDistribute = async (memberPubkey: string) => {
     if (!anchorwallet) {
+      setFormState('error')
+      setErrorMsg('Please connect your wallet!')
       return
     }
 
     try {
+      setFormState('submitting')
       setLogs([])
+
       const fanoutSdk = new FanoutClient(connection, anchorwallet)
 
-      // Generate the distribution instructions
-      let distMember = await fanoutSdk.distributeWalletMemberInstructions({
-        distributeForMint: false,
-        fanout: new PublicKey(wallet.pubkey),
+      // Prepare transaction
+      const tx = await distributeMemberTransaction({
+        fanoutSdk,
+        hydra: wallet,
         payer: anchorwallet.publicKey,
         member: new PublicKey(memberPubkey),
+        membershipModel: wallet.memberShipType,
       })
 
-      console.log(distMember?.instructions)
-
-      const tx = new Transaction()
-      tx.add(...distMember.instructions)
-
-      // Generate SPL distribution instructions (if wallet accepts SPL tokens)
-      if (wallet.acceptSPL) {
-        let distMemberSPL = await fanoutSdk.distributeWalletMemberInstructions({
-          distributeForMint: true,
-          fanout: new PublicKey(wallet.pubkey),
-          payer: anchorwallet.publicKey,
-          member: new PublicKey(memberPubkey),
-          fanoutMint: new PublicKey(wallet.splToken)
-        })
-
-        tx.add(...distMemberSPL.instructions)
+      if (!tx) {
+        setFormState('error')
+        setErrorMsg('Unsupported membership model')
+        return
       }
 
       // Sign transaction using user's wallet
@@ -203,36 +199,49 @@ const WalletDetails = ({ initialWallet, members }: WalletDetailsProps) => {
 
       const fanoutSdk = new FanoutClient(connection, anchorwallet)
 
-      const ixDistAll = await fanoutSdk.distributeAllInstructions({
-        fanout: new PublicKey(wallet.pubkey),
+      // Prepare transaction
+      const tx = await distributeAllTransaction({
+        fanoutSdk,
+        hydra: wallet,
         payer: anchorwallet.publicKey,
-        mint: NATIVE_MINT,
+        members: members.map(
+          (member: any) => new PublicKey(member.memberPubkey)
+        ),
+        membershipModel: wallet.memberShipType,
       })
 
-      if (wallet.acceptSPL) {
-        const ixDistAllSPL = await fanoutSdk.distributeAllInstructions({
-          fanout: new PublicKey(wallet.pubkey),
-          payer: anchorwallet.publicKey,
-          mint: new PublicKey(wallet.splToken),
-        })
-
-        ixDistAll.instructions = ixDistAll.instructions.concat(
-          ixDistAllSPL.instructions
-        )
-
-        ixDistAll.signers = ixDistAll.signers.concat(
-          ixDistAllSPL.signers
-        )
+      if (!tx) {
+        setFormState('error')
+        setErrorMsg('Unsupported membership model')
+        return
       }
 
-      await fanoutSdk.executeBig(Promise.resolve(ixDistAll))
+      // Sign transaction using user's wallet
+      tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash
+      tx.feePayer = anchorwallet.publicKey
+      const txSigned = await anchorwallet.signTransaction(tx)
 
-      setFormState('success')
-      setTimeout(function () {
-        setFormState('idle')
-        fetchData()
-      }, 1000)
+      // Send transaction
+      const signature = await connection.sendRawTransaction(
+        txSigned.serialize()
+      )
+      const result = await connection.confirmTransaction({
+        signature,
+        ...(await connection.getLatestBlockhash()),
+      })
 
+      if (result.value.err) {
+        setFormState('error')
+        setErrorMsg(
+          `Failed to confirm transaction: ${result.value.err.toString()}`
+        )
+      } else {
+        setFormState('success')
+        setTimeout(function () {
+          setFormState('idle')
+          fetchData()
+        }, 1000)
+      }
     } catch (error: any) {
       console.error(error)
       setLogs(error.logs)
@@ -426,4 +435,4 @@ const WalletDetails = ({ initialWallet, members }: WalletDetailsProps) => {
   )
 }
 
-export default WalletDetails;
+export default WalletDetails

--- a/utils/distribute.ts
+++ b/utils/distribute.ts
@@ -1,0 +1,78 @@
+import { FanoutClient } from '@glasseaters/hydra-sdk'
+import { PublicKey, Transaction } from '@solana/web3.js'
+
+type DistributeMemberArgs = {
+  fanoutSdk: FanoutClient
+  hydra: any
+  payer: PublicKey
+  member: PublicKey
+  membershipModel: string
+}
+
+type DistributeAllArgs = {
+  fanoutSdk: FanoutClient
+  hydra: any
+  payer: PublicKey
+  members: PublicKey[]
+  membershipModel: string
+}
+
+const distributeWalletMemberTransaction = async (
+  args: DistributeMemberArgs
+) => {
+  const { fanoutSdk, hydra, payer, member } = args
+
+  const tx = new Transaction()
+
+  const ixDistSOL = await fanoutSdk.distributeWalletMemberInstructions({
+    distributeForMint: false,
+    fanout: new PublicKey(hydra.pubkey),
+    payer,
+    member,
+  })
+
+  tx.add(...ixDistSOL.instructions)
+
+  if (hydra.acceptSPL) {
+    const ixDistSPL = await fanoutSdk.distributeWalletMemberInstructions({
+      distributeForMint: true,
+      fanout: new PublicKey(hydra.pubkey),
+      payer,
+      member,
+      fanoutMint: new PublicKey(hydra.splToken),
+    })
+
+    tx.add(...ixDistSPL.instructions)
+  }
+
+  return tx
+}
+
+const distributeMemberTransactionTable = {
+  ['Wallet membership']: distributeWalletMemberTransaction,
+}
+
+export const distributeMemberTransaction = async (
+  args: DistributeMemberArgs
+): Promise<Transaction | undefined> => {
+  const { membershipModel } = args
+  const distributeFn = distributeMemberTransactionTable[membershipModel]
+  return distributeFn ? distributeFn(args) : undefined
+}
+
+export const distributeAllTransaction = async (args: DistributeAllArgs) => {
+  const { membershipModel, members } = args
+  const distributeFn = distributeMemberTransactionTable[membershipModel]
+
+  if (!distributeFn) {
+    return undefined
+  }
+
+  const tx = new Transaction()
+  const txMembers = await Promise.all(
+    members.map((member) => distributeFn({ ...args, member }))
+  )
+  tx.add(...txMembers)
+
+  return tx
+}


### PR DESCRIPTION
Separate out the logic responsible for generating the distribution transactions in order to make it easier to add support for other membership models.

I also modified the distribute-all functionality so that it's not based on Hydra SDK's `distributeAllInstructions` because it triggers some dependency problems with other membership models.

CC: @Apra487 