### PR TITLE
dismiss alerts when closing modals

### DIFF
--- a/components/AddMemberModal.tsx
+++ b/components/AddMemberModal.tsx
@@ -227,6 +227,7 @@ const AddMemberModal = ({
           id="add-member-modal"
           className="modal-toggle"
           ref={toggleRef}
+          onChange={(e) => setFormState('idle') }
         />
         <label
           htmlFor="add-member-modal"

--- a/components/FundWalletModal.tsx
+++ b/components/FundWalletModal.tsx
@@ -124,13 +124,14 @@ const FundWalletModal = ({
       } else {
         setFormState('success')
         updateRefresh({ msg: 'success' })
-        resetForm()
       }
     } catch (error: any) {
       setErrorLogs(error.logs)
       setFormState('error')
       setErrorMsg(`Failed to fund wallet: ${error.message}`)
     }
+
+    resetForm()
   }
 
   const validate = async (values: FormValues) => {


### PR DESCRIPTION
Hide the modal's success or error alert when the user closes it so he doesn't find old messages when he opens it again (example: to add a new member he shouldn't be stuck with the old success alert while filling the form) 